### PR TITLE
Improved behavior when executing "new_cop" task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ task :new_cop, [:cop] do |_task, args|
 
   generator.write_source
   generator.write_spec
-  generator.inject_require(root_file_path: 'lib/sevencop.rb')
+  generator.inject_require(root_file_path: 'lib/rubocop/cop/sevencop.rb')
   generator.inject_config(config_file_path: 'config/default.yml')
 
   puts generator.todo

--- a/lib/rubocop/cop/sevencop.rb
+++ b/lib/rubocop/cop/sevencop.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative 'sevencop/order_field'
+require_relative 'sevencop/redundant_existence_check'
+require_relative 'sevencop/uniqueness_validator_explicit_case_sensitivity'

--- a/lib/sevencop.rb
+++ b/lib/sevencop.rb
@@ -6,10 +6,6 @@ require 'yaml'
 require_relative 'sevencop/inject'
 require_relative 'sevencop/version'
 
-require_relative 'rubocop/cop/sevencop/order_field'
-require_relative 'rubocop/cop/sevencop/redundant_existence_check'
-require_relative 'rubocop/cop/sevencop/uniqueness_validator_explicit_case_sensitivity'
-
 module Sevencop
   PROJECT_ROOT = ::Pathname.new(__dir__).parent.expand_path.freeze
 
@@ -21,3 +17,5 @@ module Sevencop
 end
 
 Sevencop::Inject.defaults!
+
+require_relative 'rubocop/cop/sevencop'


### PR DESCRIPTION
Currently, when executing `bundle exec rake 'new_cop[Foo/Bar]'`, the `require_relative 'rubocop/cop/foo/bar'` statement was added to the line below.
https://github.com/r7kamura/sevencop/blob/c63e00c6d5c66d105c8f52369608c4bf1256546d/lib/sevencop.rb#L23

At that time, I needed to move around the following in a nice way.
https://github.com/r7kamura/sevencop/blob/c63e00c6d5c66d105c8f52369608c4bf1256546d/lib/sevencop.rb#L9-L11

This is a measure to reduce this little hassle.