### PR TITLE
Remove unnecessary method names check from OrderField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Removed
+
+- Remove unnecessary method names check on `Sevencop/OrderField`.
+
 ## 0.5.1 - 2022-06-28
 
 ### Fixed

--- a/lib/rubocop/cop/sevencop/order_field.rb
+++ b/lib/rubocop/cop/sevencop/order_field.rb
@@ -32,11 +32,9 @@ module RuboCop
           reorder
         ].freeze
 
-        ORDER_METHOD_NAMES = RESTRICT_ON_SEND.to_set.freeze
-
         def_node_matcher :order_with_field?, <<~PATTERN
           (send
-            _ ORDER_METHOD_NAMES
+            _ _
             {
               (str /field\(.+\)/) |
               (dstr <(str /field\(.+\)/) ...>)


### PR DESCRIPTION
RESTRICT_ON_SEND is already doing this task, so we don't need the same work by hand.