### PR TITLE
Replace meaningless `{hash kwargs}` pattern with `hash`

### DIFF
--- a/lib/rubocop/cop/sevencop/rails_inferred_spec_type.rb
+++ b/lib/rubocop/cop/sevencop/rails_inferred_spec_type.rb
@@ -71,7 +71,7 @@ module RuboCop
             _
             _
             _*
-            ({ hash | kwargs }
+            (hash
               (pair ...)*
               $(pair (sym :type) sym)
               (pair ...)*

--- a/lib/rubocop/cop/sevencop/rails_where_not.rb
+++ b/lib/rubocop/cop/sevencop/rails_where_not.rb
@@ -22,7 +22,7 @@ module RuboCop
         def_node_matcher :rails_where_not_with_multiple_elements_hash?, <<~PATTERN
           (send
             (send _ :where) :not
-            ({ hash | kwargs }
+            (hash
               (pair _ _)
               (pair _ _)+))
         PATTERN


### PR DESCRIPTION
`kwargs` is not met in pattern-matching.
