### PR TITLE
Use ruby 3.3 on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.7'
+          - '3.3'
     runs-on: ubuntu-latest
     env:
       BUNDLE_ONLY: default:test


### PR DESCRIPTION
Mainly for `bump-request` compatibility.